### PR TITLE
Update release workflow and target ABI version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,8 @@ jobs:
       - name: Prepare plugin contents
         run: |
           mkdir -p dist/${{ env.ASSEMBLY_NAME }}
-          SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ env.ASSEMBLY_NAME }}-${{ steps.ver.outputs.version }}.zip"
+          TAG="v${{ steps.ver.outputs.version }}"
+          SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${{ env.ASSEMBLY_NAME }}-${{ steps.ver.outputs.version }}.zip"
           jq \
             --arg v "${{ steps.ver.outputs.version }}" \
             --arg src "$SOURCE_URL" \

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "User Switcher",
   "guid": "e0a4a1a2-5b6b-4e9d-88b1-1c71f0b9b0ab",
   "version": "0.1.0",
-  "targetAbi": "10.10.0.0",
+  "targetAbi": "10.10.7.0",
   "framework": "net8.0",
   "owner": "TechBrew",
   "overview": "Admin-only tools to impersonate users and authorize Quick Connect codes.",


### PR DESCRIPTION
Modified the GitHub Actions release workflow to use a versioned tag for the source URL. Updated manifest.json to target ABI version 10.10.7.0 for compatibility.